### PR TITLE
Fix symlink path for lua-language-server

### DIFF
--- a/dev/lsp-installer/install.ab
+++ b/dev/lsp-installer/install.ab
@@ -76,7 +76,7 @@ main {
         $git pull$
         $./make.sh$
     }
-    symlink_create("/opt/lua-language-server/bin/lua-language-server", "/usr/local/bin/lua-language-server")?
+    symlink_create("/opt/lua-language-server/lua-language-server", "/usr/local/bin/lua-language-server")?
 
     cd "/tmp"
 


### PR DESCRIPTION
The lua-language-server binary doesn't exist in ,
/opt/lua-language-server/bin/
 Instead it exists in ,
/opt/lua-language-server/